### PR TITLE
添加了排行榜缓存优化

### DIFF
--- a/controllers/RatingController.php
+++ b/controllers/RatingController.php
@@ -12,35 +12,62 @@ class RatingController extends BaseController
 {
     public function actionIndex()
     {
-
         if (Yii::$app->setting->get('isContestMode') && (Yii::$app->user->isGuest || (!Yii::$app->user->identity->isAdmin()))) {
             throw new ForbiddenHttpException('You are not allowed to perform this action.');
         }
-        $query = (new Query())->select('u.id, u.nickname, p.student_number, u.rating, s.solved')
-            ->from('{{%user}} AS u')
-            ->leftJoin(
-                '(SELECT COUNT(DISTINCT problem_id) AS solved, created_by FROM {{%solution}} WHERE result=4 GROUP BY created_by ORDER BY solved DESC) as s',
-                'u.id=s.created_by'
-            )
-            ->leftJoin('`user_profile` `p` ON `p`.`user_id`=`u`.`id`')
-            ->orderBy('solved DESC, id');
-        $top3users = $query->limit(3)->all();
-        $defaultPageSize = 50;
-        $countQuery = clone $query;
-        $pages = new Pagination([
-            'totalCount' => $countQuery->count(),
-            'defaultPageSize' => $defaultPageSize
-        ]);
-        $users = $query->offset($pages->offset)
-            ->limit($pages->limit)
-            ->all();
 
-        return $this->render('index', [
-            'top3users' => $top3users,
-            'users' => $users,
-            'pages' => $pages,
-            'currentPage' => $pages->page,
-            'defaultPageSize' => $defaultPageSize
-        ]);
+        // 缓存键
+        $cacheKey = 'rating-index-data';
+        // 尝试从缓存中获取数据
+        $data = Yii::$app->cache->get($cacheKey);
+
+        if ($data === false) {
+            // 缓存中没有数据，执行数据库查询
+            $query = (new Query())->select('u.id, u.nickname, p.student_number, u.rating, s.solved')
+                ->from('{{%user}} AS u')
+                ->leftJoin(
+                    '(SELECT COUNT(DISTINCT problem_id) AS solved, created_by FROM {{%solution}} WHERE result=4 GROUP BY created_by ORDER BY solved DESC) as s',
+                    'u.id=s.created_by'
+                )
+                ->leftJoin('`user_profile` `p` ON `p`.`user_id`=`u`.`id`')
+                ->orderBy('solved DESC, id');
+            $top3users = $query->limit(3)->all();
+            $defaultPageSize = 50;
+            $countQuery = clone $query;
+            $pages = new Pagination([
+                'totalCount' => $countQuery->count(),
+                'defaultPageSize' => $defaultPageSize
+            ]);
+            $users = $query->offset($pages->offset)
+                ->limit($pages->limit)
+                ->all();
+
+            // 将查询结果和当前时间保存到缓存中
+            $currentTimestamp = time();
+            // 将查询结果保存到缓存中，设置有效期为 600 秒（10分钟）
+            $data = [
+                'top3users' => $top3users,
+                'users' => $users,
+                'pages' => $pages,
+                'currentPage' => $pages->page,
+                'defaultPageSize' => $defaultPageSize,
+                'lastUpdated' => $currentTimestamp
+            ];
+            Yii::$app->cache->set($cacheKey, $data, 600);
+        }
+
+        // 使用缓存或新查询的数据渲染视图
+        return $this->render('index', $data);
     }
+
+    public function actionClearCache()
+    {
+        if (Yii::$app->user->isGuest || !Yii::$app->user->identity->isAdmin()) {
+            throw new ForbiddenHttpException('You are not allowed to perform this action.');
+        }
+        Yii::$app->cache->delete('rating-index-data');
+        Yii::$app->session->setFlash('success', 'Cache cleared successfully.');
+        return $this->redirect(['index']); // 重定向回主页面
+    }
+
 }

--- a/views/rating/index.php
+++ b/views/rating/index.php
@@ -14,6 +14,24 @@ use yii\helpers\Html;
 $this->title = Yii::t('app', 'Rating');
 ?>
 
+<style>
+    .btn-custom {
+        font-size: 0.8rem; /* 调整字体大小 */
+        padding: .335rem .65rem; /* 调整内边距以适应新的字体大小 */
+    }
+</style>
+<div class="row">
+    <div class="col">
+        <?php if (isset($lastUpdated)): ?>
+            <p style="display: inline-block; margin-right: 10px;">榜单更新时间： <?= Yii::$app->formatter->asDatetime($lastUpdated) ?></p>
+        <?php endif; ?>
+        <?php if (!Yii::$app->user->isGuest && Yii::$app->user->identity->isAdmin()): ?>
+            <?= Html::a('刷新榜单', ['rating/clear-cache'], ['class' => 'btn btn-warning btn-custom', 'style' => 'display: inline-block; vertical-align: middle;']) ?>
+        <?php endif; ?>
+    </div>
+</div>
+
+
 <div class="row">
     <div class="col">
         <div class="rating-index">
@@ -54,5 +72,4 @@ $this->title = Yii::t('app', 'Rating');
         </div>
         <p></p>
     </div>
-
 </div>


### PR DESCRIPTION
对过题数排行榜，查询耗时长，为了降低频繁查询的数据库压力：

- 基于 Yii 自带的 cache，每 10 分钟更新一次排行榜
- 管理员可以手动立即刷新排行榜
- 前端会显示最近一次更新排行榜的具体时间