### PR TITLE
fix: Login performance issue

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -69,6 +69,17 @@ $config = [
                 'standing/<id:\d+>' => '/contest/standing2'
             ],
         ],
+        'session' => [
+            'class' => 'yii\web\DbSession',
+            // Set the following if you want to use DB component other than
+            // default 'db'.
+            // 'db' => 'mydb',
+            // To override default session table, set the following
+            // 'sessionTable' => 'my_session',
+        ],
+        'security' => [
+            'passwordHashCost' => 10, // 尝试调整这个值
+        ],
     ],
     'params' => $params,
 ];

--- a/migrations/m241114_082321_create_session.php
+++ b/migrations/m241114_082321_create_session.php
@@ -1,0 +1,45 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m241114_082321_create_session
+ */
+class m241114_082321_create_session extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('session', [
+            'id' => $this->char(40)->notNull(),
+            'expire' => $this->integer(),
+            'data' => $this->binary(),
+        ]);
+        $this->addPrimaryKey('pk_session_id', 'session', 'id');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropTable('session');
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m241114_082321_create_session cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}


### PR DESCRIPTION
yii2 默认密码hash加密cost的值太高，导致加密缓慢，多用户同时登陆时系统卡慢，经过测试10个用户同时登录的工况共登录400个账号用时120s左右。将cost下调至10之后用时30s，和用户不存在（不需要加解密）的工况的用时在误差范围内。