### PR TITLE
ci: Specify phpstan version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           path: assets/ commands/ components/ config/ controllers/ mail/ messages/ migrations/ models/ modules/ views/ web/ widgets/
           php_version: "${{ matrix.php-version }}"
+          version: 2
           autoload_file: vendor/yiisoft/yii2/Yii.php
           memory_limit: 512M
           level: "0"
@@ -65,6 +66,7 @@ jobs:
         with:
           path: assets/ commands/ components/ config/ controllers/ mail/ messages/ migrations/ models/ modules/ views/ web/ widgets/
           php_version: "${{ matrix.php-version }}"
+          version: 2
           autoload_file: vendor/yiisoft/yii2/Yii.php
           memory_limit: 512M
           level: "1"


### PR DESCRIPTION
https://github.com/php-actions/phpstan/commit/7d5a03f0608aa4dc3013fa1b9100abfb590cf9b8


We can use 2 here since we don't support php < 7.4 and looks like the [new rules (level 0)](https://github.com/phpstan/phpstan/releases/tag/2.0.0) still pass for us.