### PR TITLE
ci: unbreak phpstan again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,8 +83,8 @@ jobs:
           - "judge"
           - "polygon"
         ubuntu-version:
+          - "ubuntu-24.04"
           - "ubuntu-22.04"
-          - "ubuntu-20.04"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           path: assets/ commands/ components/ config/ controllers/ mail/ messages/ migrations/ models/ modules/ views/ web/ widgets/
           php_version: "${{ matrix.php-version }}"
-          version: 2
+          version: '2.*'
           autoload_file: vendor/yiisoft/yii2/Yii.php
           memory_limit: 512M
           level: "0"
@@ -66,7 +66,7 @@ jobs:
         with:
           path: assets/ commands/ components/ config/ controllers/ mail/ messages/ migrations/ models/ modules/ views/ web/ widgets/
           php_version: "${{ matrix.php-version }}"
-          version: 2
+          version: '2.*'
           autoload_file: vendor/yiisoft/yii2/Yii.php
           memory_limit: 512M
           level: "1"


### PR DESCRIPTION
https://www.getrelease.download/phpstan/phpstan/2/phar no longer provides a valid download.

Use https://www.getrelease.download/phpstan/phpstan/2.*/phar instead.